### PR TITLE
Apply symbol viewBox to symbol's path data

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
   <head>
   </head>
   <body>
-      <svg width="500">
+      <svg id="root" width="500">
         <defs>
           <symbol viewBox="0 0 88 72" id="poly">
               <path d="M 0 36 18 0 70 0 88 36 70 72 18 72Z"></path>

--- a/src/PathHandler.js
+++ b/src/PathHandler.js
@@ -6,8 +6,8 @@
 
 
 
-if (typeof module !== "undefine") {
-  var Shapes = require('kld-intersections').Shapes;
+if (typeof module !== "undefined") {
+  var { Point2D, Matrix2D, AffineShapes } = require('kld-intersections');
 }
 
 /**
@@ -15,7 +15,8 @@ if (typeof module !== "undefine") {
 *
 *  @constructor
 */
-function PathHandler() {
+function PathHandler(matrix) {
+  this.matrix = matrix || new Matrix2D();
   this.shapes = [];
   this.firstX = null;
   this.firstY = null;
@@ -94,11 +95,11 @@ PathHandler.prototype.arcRel = function(rx, ry, xAxisRotation, largeArcFlag, swe
 *  @param {Number} y
 */
 PathHandler.prototype.curvetoCubicAbs = function(x1, y1, x2, y2, x, y) {
-  this.addShape(Shapes.cubicBezier(
-      this.lastX, this.lastY,
-      x1, y1,
-      x2, y2,
-      x, y
+  this.addShape(AffineShapes.cubicBezier(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(x1, y1)).transform(this.matrix),
+      (new Point2D(x2, y2)).transform(this.matrix),
+      (new Point2D(x, y)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -117,11 +118,11 @@ PathHandler.prototype.curvetoCubicAbs = function(x1, y1, x2, y2, x, y) {
 *  @param {Number} y
 */
 PathHandler.prototype.curvetoCubicRel = function(x1, y1, x2, y2, x, y) {
-  this.addShape(Shapes.cubicBezier(
-      this.lastX, this.lastY,
-      this.lastX + x1, this.lastY + y1,
-      this.lastX + x2, this.lastY + y2,
-      this.lastX + x, this.lastY + y
+  this.addShape(AffineShapes.cubicBezier(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX + x1, this.lastY + y1)).transform(this.matrix),
+      (new Point2D(this.lastX + x2, this.lastY + y2)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this.lastY + y)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -135,9 +136,9 @@ PathHandler.prototype.curvetoCubicRel = function(x1, y1, x2, y2, x, y) {
 *  @param {Number} x
 */
 PathHandler.prototype.linetoHorizontalAbs = function(x) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      x, this.lastY
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(x, this.lastY)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -150,9 +151,9 @@ PathHandler.prototype.linetoHorizontalAbs = function(x) {
 *  @param {Number} x
 */
 PathHandler.prototype.linetoHorizontalRel = function(x) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      this.lastX + x, this.lastY
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this.lastY)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -166,9 +167,9 @@ PathHandler.prototype.linetoHorizontalRel = function(x) {
 *  @param {Number} y
 */
 PathHandler.prototype.linetoAbs = function(x, y) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      x, y
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(x, y)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -183,9 +184,9 @@ PathHandler.prototype.linetoAbs = function(x, y) {
 *  @param {Number} y
 */
 PathHandler.prototype.linetoRel = function(x, y) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      this.lastX + x, this.lastY + y
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this.lastY + y)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -230,10 +231,10 @@ PathHandler.prototype.movetoRel = function(x, y) {
 *  @param {Number} y
 */
 PathHandler.prototype.curvetoQuadraticAbs = function(x1, y1, x, y) {
-  this.addShape(Shapes.quadraticBezier(
-      this.lastX, this.lastY,
-      x1, y1,
-      x, y
+  this.addShape(AffineShapes.quadraticBezier(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(x1, y1)).transform(this.matrix),
+      (new Point2D(x, y)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -250,10 +251,10 @@ PathHandler.prototype.curvetoQuadraticAbs = function(x1, y1, x, y) {
 *  @param {Number} y
 */
 PathHandler.prototype.curvetoQuadraticRel = function(x1, y1, x, y) {
-  this.addShape(Shapes.quadraticBezier(
-      this.lastX, this.lastY,
-      this.lastX + x1, this.lastY + y1,
-      this.lastX + x, this.lastY + y
+  this.addShape(AffineShapes.quadraticBezier(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX + x1, this.lastY + y1)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this.lastY + y)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -283,10 +284,10 @@ PathHandler.prototype.curvetoCubicSmoothAbs = function(x2, y2, x, y) {
       controlY = this.lastY;
   }
 
-  this.addShape(Shapes.cubicBezier(
-      controlX, controlY,
-      x2, y2,
-      x, y
+  this.addShape(AffineShapes.cubicBezier(
+      (new Point2D(controlX, controlY)).transform(this.matrix),
+      (new Point2D(x2, y2)).transform(this.matrix),
+      (new Point2D(x, y)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -316,10 +317,10 @@ PathHandler.prototype.curvetoCubicSmoothRel = function(x2, y2, x, y) {
       controlY = this.lastY;
   }
 
-  this.addShape(Shapes.cubicBezier(
-      controlX, controlY,
-      this.lastX + x2, this.lastY + y2,
-      this.lastX + x, this.lastY + y
+  this.addShape(AffineShapes.cubicBezier(
+      (new Point2D(controlX, controlY)).transform(this.matrix),
+      (new Point2D(this.lastX + x2, this.lastY + y2)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this.lastY + y)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -347,9 +348,9 @@ PathHandler.prototype.curvetoQuadraticSmoothAbs = function(x, y) {
       controlY = this.lastY;
   }
 
-  this.addShape(Shapes.quadraticBezier(
-      controlX, controlY,
-      x, y
+  this.addShape(AffineShapes.quadraticBezier(
+      (new Point2D(controlX, controlY)).transform(this.matrix),
+      (new Point2D(x, y)).transform(this.matrix)
   ));
 
   this.lastX = x;
@@ -377,9 +378,9 @@ PathHandler.prototype.curvetoQuadraticSmoothRel = function(x, y) {
       controlY = this.lastY;
   }
 
-  this.addShape(Shapes.quadraticBezier(
-      controlX, controlY,
-      this.lastX + x, this,lastY + y
+  this.addShape(AffineShapes.quadraticBezier(
+      (new Point2D(controlX, controlY)).transform(this.matrix),
+      (new Point2D(this.lastX + x, this,lastY + y)).transform(this.matrix)
   ));
 
   this.lastX += x;
@@ -393,9 +394,9 @@ PathHandler.prototype.curvetoQuadraticSmoothRel = function(x, y) {
 *  @param {Number} y
 */
 PathHandler.prototype.linetoVerticalAbs = function(y) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      this.lastX, y
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX, y)).transform(this.matrix)
   ));
 
   this.lastY = y;
@@ -409,9 +410,9 @@ PathHandler.prototype.linetoVerticalAbs = function(y) {
 *  @param {Number} y
 */
 PathHandler.prototype.linetoVerticalRel = function(y) {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      this.lastX, this.lastY + y
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.lastX, this.lastY + y)).transform(this.matrix)
   ));
 
   this.lastY += y;
@@ -423,9 +424,9 @@ PathHandler.prototype.linetoVerticalRel = function(y) {
 *  closePath - z or Z
 */
 PathHandler.prototype.closePath = function() {
-  this.addShape(Shapes.line(
-      this.lastX, this.lastY,
-      this.firstX, this.firstY
+  this.addShape(AffineShapes.line(
+      (new Point2D(this.lastX, this.lastY)).transform(this.matrix),
+      (new Point2D(this.firstX, this.firstY)).transform(this.matrix)
   ));
 
   this.lastX = this.firstX,
@@ -433,6 +434,6 @@ PathHandler.prototype.closePath = function() {
   this.lastCommand = "z";
 };
 
-if (typeof module !== "undefine") {
+if (typeof module !== "undefined") {
   module.exports = PathHandler;
 }

--- a/src/ViewBox.js
+++ b/src/ViewBox.js
@@ -1,0 +1,112 @@
+if (typeof module !== "undefined") {
+  var Matrix2D = require('kld-intersections').Matrix2D;
+}
+
+
+class ViewBox {
+    constructor(viewBox, preserveAspectRatio, bbox) {
+        if ( viewBox != null && viewBox != "" ) {
+            const params = viewBox.split(/\s*,\s*|\s+/);
+
+            this.x      = parseFloat( params[0] );
+            this.y      = parseFloat( params[1] );
+            this.width  = parseFloat( params[2] );
+            this.height = parseFloat( params[3] );
+        }
+        else {
+            this.x      = 0;
+            this.y      = 0;
+            this.width  = bbox.width;
+            this.height = bbox.height;
+        }
+
+        this.setPAR(preserveAspectRatio);
+    }
+
+    getTM(bbox) {
+        var matrix = new Matrix2D();
+
+        let windowWidth = bbox.width;
+        let windowHeight = bbox.height;
+
+        var x_ratio = this.width  / windowWidth;
+        var y_ratio = this.height / windowHeight;
+
+        matrix = matrix.translate(this.x, this.y);
+
+        if ( this.alignX == "none" ) {
+            matrix = matrix.scaleNonUniform( x_ratio, y_ratio );
+        }
+        else {
+            if ( x_ratio < y_ratio && this.meetOrSlice == "meet" ||
+                 x_ratio > y_ratio && this.meetOrSlice == "slice"   )
+            {
+                var x_trans = 0;
+                var x_diff  = windowWidth*y_ratio - this.width;
+
+                if ( this.alignX == "Mid" )
+                    x_trans = -x_diff/2;
+                else if ( this.alignX == "Max" )
+                    x_trans = -x_diff;
+
+                matrix = matrix.translate(x_trans, 0);
+                matrix = matrix.scale( y_ratio );
+            }
+            else if ( x_ratio > y_ratio && this.meetOrSlice == "meet" ||
+                      x_ratio < y_ratio && this.meetOrSlice == "slice"   )
+            {
+                var y_trans = 0;
+                var y_diff  = windowHeight*x_ratio - this.height;
+
+                if ( this.alignY == "Mid" )
+                    y_trans = -y_diff/2;
+                else if ( this.alignY == "Max" )
+                    y_trans = -y_diff;
+                
+                matrix = matrix.translate(0, y_trans);
+                matrix = matrix.scale( x_ratio );
+            }
+            else
+            {
+                // x_ratio == y_ratio so, there is no need to translate
+                // We can scale by either value
+                matrix = matrix.scale( x_ratio );
+            }
+        }
+
+        return matrix;
+    }
+
+    setPAR(PAR) {
+        if ( PAR ) {
+            var params = PAR.split(/\s+/);
+            var align  = params[0];
+
+            if ( align == "none" ) {
+                this.alignX = "none";
+                this.alignY = "none";
+            }
+            else {
+                this.alignX = align.substring(1,4);
+                this.alignY = align.substring(5,9);
+            }
+
+            if ( params.length == 2 ) {
+                this.meetOrSlice = params[1];
+            }
+            else {
+                this.meetOrSlice = "meet";
+            }
+        }
+        else {
+            this.align  = "xMidYMid";
+            this.alignX = "Mid";
+            this.alignY = "Mid";
+            this.meetOrSlice = "meet";
+        }
+    }
+}
+
+if (typeof module !== "undefined") {
+  module.exports = ViewBox;
+}

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,8 +1,22 @@
 import { Intersection, Shapes } from 'kld-intersections';
 import { PathParser } from 'kld-path-parser';
 import * as PathHandler from './PathHandler';
+import * as ViewBox from './ViewBox';
+
+const svgns = "http://www.w3.org/2000/svg";
 
 // Code based on https://github.com/thelonious/kld-intersections/blob/development/examples/path-line.js
+
+const svg = document.getElementById("root");
+
+const poly = document.getElementById('poly');
+const viewbox = new ViewBox(
+	poly.getAttributeNS(null, "viewBox"),
+	poly.getAttributeNS(null, "preserveAspectRatio"),
+	svg.getBoundingClientRect()
+);
+const viewbox_matrix = viewbox.getTM(svg.getBoundingClientRect());
+console.log(viewbox_matrix);
 
 const lineElem = document.getElementById('line');
 const linePoint1x = parseInt(lineElem.getAttribute('x1'), 10);
@@ -10,21 +24,32 @@ const linePoint1y = parseInt(lineElem.getAttribute('y1'), 10);
 const linePoint2x = parseInt(lineElem.getAttribute('x2'), 10);
 const linePoint2y = parseInt(lineElem.getAttribute('y2'), 10);
 
-const pathElem = document.querySelector('#poly path');
+const pathElem = document.querySelector('#poly path') as SVGPathElement;
 const pathData = pathElem.getAttribute('d');
-
-// What about pathViewBox?
+console.log(pathData);
 
 const parser = new PathParser();
-const handler = new PathHandler();
+const handler = new PathHandler(viewbox_matrix.inverse());
 
 parser.setHandler(handler);
 parser.parseData(pathData);
+console.log(handler.shapes);
 
 const path = Shapes.path(handler.shapes);
-
-let line = Shapes.line(linePoint1x, linePoint1y, linePoint2x, linePoint2y);
-
+const line = Shapes.line(linePoint1x, linePoint1y, linePoint2x, linePoint2y);
 const pathIntersect = Intersection.intersect(path, line);
+
+for (let p of pathIntersect.points) {
+	let circle = document.createElementNS(svgns, "circle");
+
+	circle.setAttributeNS(null, "cx", p.x.toString());
+	circle.setAttributeNS(null, "cy", p.y.toString());
+	circle.setAttributeNS(null, "r", "3");
+	circle.setAttributeNS(null, "fill", "none");
+	circle.setAttributeNS(null, "stroke", "red");
+	// circle.setAttributeNS(null, "stroke-width", "0.5");
+
+	svg.appendChild(circle);
+}
 
 console.log('Line intersects path at: ', pathIntersect);


### PR DESCRIPTION
This pulls in an old class I had on KevLinDev that converts an SVG element's viewBox and preserveAspectRatio attributes to an SVGMatrix. I've hacked the code to work with kld-affine classes. 

In order to transform the symbol's path data, I had to update PathHandler to apply a matrix to all points it processes. Since these transformed points are kld-affine Point2D instances, I switched over to using AffineShapes in place of Shapes.

The sample appears to work, but I suspect there are latent issues with these changes as none of this has been tested. Also, I've been out of the SVG world for a long time now. It's very likely there is a DOM method that gives you the same matrix ViewBox is calculating, but a quick search didn't come up with anything obvious to me.